### PR TITLE
Update CMake Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,17 @@ set(CMAKE_CXX_STANDARD 20)
 
 include(FetchContent)
 
+
+#
+#  Options
+#
+option(METALLDATA_USE_PRIVATEER "Use Privateer in Metall" ON)
+if (APPLE AND METALLDATA_USE_PRIVATEER)
+    message(WARNING "Turn off Privateer on MacOS")
+    set(METALLDATA_USE_PRIVATEER OFF)
+endif ()
+
+
 #
 #  Threads
 #
@@ -80,13 +91,15 @@ endif ()
 #
 # Privateer
 #
-find_package(Privateer QUIET)
-if (NOT Privateer_FOUND)
-   FetchContent_Declare(Privateer
-           GIT_REPOSITORY https://github.com/LLNL/Privateer.git
-           GIT_TAG feature/uffd
-           )
-   FetchContent_MakeAvailable(Privateer)
+if (METALLDATA_USE_PRIVATEER)
+    find_package(Privateer QUIET)
+    if (NOT Privateer_FOUND)
+        FetchContent_Declare(Privateer
+                GIT_REPOSITORY https://github.com/LLNL/Privateer.git
+                GIT_TAG feature/uffd
+                )
+        FetchContent_MakeAvailable(Privateer)
+    endif ()
 endif ()
 
 #
@@ -95,9 +108,14 @@ endif ()
 find_package(Metall QUIET)
 if (NOT Metall_FOUND)
     set(JUST_INSTALL_METALL_HEADER TRUE)
+    if (Privateer_FOUND)
+        set(METALL_GIT_TAG "privateer2.0")
+    else()
+        set(METALL_GIT_TAG "develop")
+    endif()
     FetchContent_Declare(Metall
             GIT_REPOSITORY https://github.com/LLNL/metall.git
-            GIT_TAG privateer2.0
+            GIT_TAG ${METALL_GIT_TAG}
             )
     FetchContent_MakeAvailable(Metall)
 endif ()
@@ -202,19 +220,23 @@ endfunction()
 #
 function(setup_metall_target exe_name)
     target_include_directories(${exe_name} PRIVATE ${Boost_INCLUDE_DIRS})
-    target_include_directories(${exe_name} PRIVATE "${Privateer_SOURCE_DIR}/include")
 
-    find_package(OpenSSL)
-    target_link_libraries(${exe_name} PRIVATE OpenSSL::SSL)
-    target_link_libraries(${exe_name} PRIVATE OpenSSL::Crypto)
-    target_link_libraries(${exe_name} PRIVATE rt)
-    target_link_libraries(${exe_name} PRIVATE Threads::Threads)
-    target_link_libraries(${exe_name} PRIVATE zstd)
+    if (Privateer_FOUND)
+        target_include_directories(${exe_name} PRIVATE "${Privateer_SOURCE_DIR}/include")
 
-    target_compile_definitions(${exe_name} PRIVATE USE_COMPRESSION)
-    target_link_libraries(${exe_name} PRIVATE privateer-static)
+        find_package(OpenSSL)
+        target_link_libraries(${exe_name} PRIVATE OpenSSL::SSL)
+        target_link_libraries(${exe_name} PRIVATE OpenSSL::Crypto)
+        target_link_libraries(${exe_name} PRIVATE rt)
+        target_link_libraries(${exe_name} PRIVATE Threads::Threads)
+        target_link_libraries(${exe_name} PRIVATE zstd)
 
-    target_compile_definitions(${exe_name} PRIVATE METALL_USE_PRIVATEER)
+        target_compile_definitions(${exe_name} PRIVATE USE_COMPRESSION)
+
+        target_link_libraries(${exe_name} PRIVATE privateer-static)
+        target_compile_definitions(${exe_name} PRIVATE METALL_USE_PRIVATEER)
+    endif ()
+
     target_link_libraries(${exe_name} PRIVATE Metall)
 
     if (FOUND_CXX17_FILESYSTEM_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ endfunction()
 function(setup_metall_target exe_name)
     target_include_directories(${exe_name} PRIVATE ${Boost_INCLUDE_DIRS})
 
+    target_link_libraries(${exe_name} PRIVATE Threads::Threads)
     if (Privateer_FOUND)
         target_include_directories(${exe_name} PRIVATE "${Privateer_SOURCE_DIR}/include")
 
@@ -230,7 +231,6 @@ function(setup_metall_target exe_name)
         target_link_libraries(${exe_name} PRIVATE OpenSSL::SSL)
         target_link_libraries(${exe_name} PRIVATE OpenSSL::Crypto)
         target_link_libraries(${exe_name} PRIVATE rt)
-        target_link_libraries(${exe_name} PRIVATE Threads::Threads)
         target_link_libraries(${exe_name} PRIVATE zstd)
 
         target_compile_definitions(${exe_name} PRIVATE USE_COMPRESSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,18 +29,19 @@ find_package(Threads REQUIRED)
 
 #
 # Boost
-find_package(Boost 1.80 QUIET)
-if (NOT Boost_FOUND)
-    FetchContent_Declare(Boost
-            URL https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.bz2)
-    FetchContent_GetProperties(Boost)
-    if (NOT Boost_POPULATED)
-        FetchContent_Populate(Boost)
-    endif ()
-    set(BOOST_ROOT ${boost_SOURCE_DIR})
-    find_package(Boost 1.80)
-endif ()
-
+include(setup_boost)
+prepare_fetchcontent_boost()
+set(FETCHCONTENT_QUIET FALSE)
+FetchContent_Declare(
+        Boost
+        GIT_REPOSITORY https://github.com/boostorg/boost.git
+        GIT_TAG boost-1.78.0
+        GIT_SUBMODULES ${BOOST_REQD_SUBMODULES}
+        GIT_PROGRESS TRUE
+        CONFIGURE_COMMAND ""  # tell CMake it's not a cmake project
+)
+FetchContent_MakeAvailable(Boost)
+get_boost_include_dirs()
 
 #
 #  cereal
@@ -169,7 +170,8 @@ endfunction()
 function(add_metalldata_executable name source)
     add_executable(${name} ${source})
     add_common_compile_options(${name})
-    target_include_directories(${name} PRIVATE ${PROJECT_SOURCE_DIR}/include)
+    target_include_directories(${name} PRIVATE ${PROJECT_SOURCE_DIR}/include ${BOOST_INCLUDE_DIRS})
+    target_link_libraries(${name} PRIVATE Boost::json)
 endfunction()
 
 

--- a/cmake/setup_boost.cmake
+++ b/cmake/setup_boost.cmake
@@ -1,0 +1,79 @@
+function(prepare_fetchcontent_boost)
+    set(BOOST_INCLUDE_LIBRARIES json PARENT_SCOPE)
+    set(BOOST_ENABLE_CMAKE ON PARENT_SCOPE)
+
+    set(BOOST_REQD_SUBMODULES
+            "tools/cmake;"
+            "libs/assert;"
+            "libs/exception;"
+            "libs/throw_exception;"
+            "libs/static_assert;"
+            "libs/config;"
+            "libs/container;"
+            "libs/container_hash;"
+            "libs/utility;"
+            "libs/type_traits;"
+            "libs/move;"
+            "libs/tuple;"
+            "libs/variant2;"
+            "libs/detail;"
+            "libs/smart_ptr;"
+            "libs/integer;"
+            "libs/intrusive;"
+            "libs/io;"
+            "libs/core;"
+            "libs/align;"
+            "libs/predef;"
+            "libs/preprocessor;"
+            "libs/system;"
+            "libs/winapi;"
+            "libs/mp11;"
+            "libs/json;"
+            "libs/property_tree;"
+
+            "libs/interprocess;"
+            "libs/optional;"
+            "libs/any;"
+            "libs/type_index;"
+            "libs/mpl;"
+            "libs/multi_index;"
+            "libs/serialization;"
+            "libs/bind;"
+            "libs/foreach;"
+            "libs/iterator;"
+            "libs/headers;"
+            "libs/unordered;"
+            "libs/format;"
+            "libs/range;"
+            "libs/concept_check;"
+            "libs/uuid;"
+            "libs/random;"
+            "libs/tti;"
+            "libs/function_types;"
+            PARENT_SCOPE)
+endfunction()
+
+function(get_boost_include_dirs)
+    list(APPEND BOOST_INCLUDE_DIRS
+            ${Boost_SOURCE_DIR}/libs/interprocess/include
+            ${Boost_SOURCE_DIR}/libs/property_tree/include
+            ${Boost_SOURCE_DIR}/libs/optional/include
+            ${Boost_SOURCE_DIR}/libs/any/include
+            ${Boost_SOURCE_DIR}/libs/type_index/include
+            ${Boost_SOURCE_DIR}/libs/mpl/include
+            ${Boost_SOURCE_DIR}/libs/bind/include
+            ${Boost_SOURCE_DIR}/libs/multi_index/include
+            ${Boost_SOURCE_DIR}/libs/serialization/include
+            ${Boost_SOURCE_DIR}/libs/foreach/include
+            ${Boost_SOURCE_DIR}/libs/iterator/include
+            ${Boost_SOURCE_DIR}/libs/container/include
+            ${Boost_SOURCE_DIR}/libs/unordered/include
+            ${Boost_SOURCE_DIR}/libs/format/include
+            ${Boost_SOURCE_DIR}/libs/range/include
+            ${Boost_SOURCE_DIR}/libs/concept_check/include
+            ${Boost_SOURCE_DIR}/libs/uuid/include
+            ${Boost_SOURCE_DIR}/libs/random/include
+            ${Boost_SOURCE_DIR}/libs/tti/include
+            ${Boost_SOURCE_DIR}/libs/function_types/include)
+    set(BOOST_INCLUDE_DIRS ${BOOST_INCLUDE_DIRS} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
- Use the new submodule technique to get and link with Boost
- Add a CMake option (METALLDATA_USE_PRIVATEER) to turn off Privateer.
- Disable Privateer on MacOS.
