### PR TITLE
Push boost json to bento using lvalue reference

### DIFF
--- a/include/json_bento/box.hpp
+++ b/include/json_bento/box.hpp
@@ -101,7 +101,21 @@ class box {
   /// box jb;
   /// jb.push_back({{"key1", "value1" }, { "key2", 42 }});
   /// \endcode
-  index_type push_back(boost::json::value value) {
+  index_type push_back(const boost::json::value& value) {
+    return push_back_root_value(value, m_box);
+  }
+
+  /// \brief Add an item at the end.
+  /// \param value Value to add.
+  /// value can be any data type that can be parsed by boost::json::value.
+  /// \return Returns the ID of the added item.
+  /// \example
+  /// \code
+  /// boost::json::value value;
+  /// box jb;
+  /// jb.push_back(std::move(value));
+  /// \endcode
+  index_type push_back(boost::json::value&& value) {
     return push_back_root_value(value, m_box);
   }
 

--- a/src/MetallJsonLines/MetallJsonLines-merge.hpp
+++ b/src/MetallJsonLines/MetallJsonLines-merge.hpp
@@ -531,7 +531,7 @@ void computeJoin(const xpr::metall_json_lines::accessor_type& lhs,
 
 	boost::json::value val = joinRecords(lhs, lhsProjList, lhsOutFields, rhs, rhsProjList, rhsOutFields);
 
-  // res.append_local(std::move(val));
+  //res.append_local(val);
 }
 
 

--- a/src/MetallJsonLines/MetallJsonLines.hpp
+++ b/src/MetallJsonLines/MetallJsonLines.hpp
@@ -428,10 +428,12 @@ struct metall_json_lines {
 
   /// appends a single element to the local container
   /// \{
-  accessor_type append_local(boost::json::value val = {}) {
-    vector.push_back(std::move(val));
+  accessor_type append_local(const boost::json::value& val = {}) {
+    // No benefit of moving boost object to JSON Bento now.
+    vector.push_back(val);
     return vector.back();
   }
+
   //~ accessor_type append_local() { return append_local(boost::json::value{}); }
   /// \}
 


### PR DESCRIPTION
Hi Peter,

This optimization may increase the performance of line 534 in MetallJsonLines-merge.hpp.
Could you try this?