### PR TITLE
Update jsonlogic integration to new logic_rule API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(JSONLOGIC_ENABLE_BENCH OFF)
 set(JSONLOGIC_ENABLE_TESTS OFF)
 FetchContent_Declare(CLIPPy
         GIT_REPOSITORY https://github.com/LLNL/clippy-cpp.git
-        GIT_TAG v0.4
+        GIT_TAG jl_nojson
         )
         FetchContent_MakeAvailable(CLIPPy)
 set(CLIPPy_INCLUDE_DIR "${clippy_SOURCE_DIR}/include")

--- a/src/bench/filter_to_parquet_cmd.hpp
+++ b/src/bench/filter_to_parquet_cmd.hpp
@@ -183,11 +183,9 @@ class filter_to_parquet_cmd : public base_subcommand {
     std::vector<bjsn::string> vars;
     jsonlogic::any_expr       expression_rule;
 
-    std::tie(expression_rule, vars, std::ignore) =
-        jsonlogic::create_logic(jl_rule);
-
-    // jsonlogic::expr*                 rawexpr = expression_rule_.release();
-    // std::shared_ptr<jsonlogic::expr> expression_rule{rawexpr};
+    // this is not used ... PP (12/12/25)
+    // was: std::tie(expression_rule, vars, std::ignore) = jsonlogic::create_logic(jl_rule);
+    // new: jsonlogic::logic_rule jlrule = jsonlogic::create_logic(jl_rule);
 
     std::set<std::string> varset{};
     for (auto v : vars) {

--- a/src/bench/remove_if2_cmd.hpp
+++ b/src/bench/remove_if2_cmd.hpp
@@ -72,13 +72,9 @@ class remove_if2_cmd : public base_subcommand {
     std::vector<size_t> records_to_erase;
 
     std::vector<bjsn::string> vars;
-    jsonlogic::any_expr       expression_rule;
-
-    std::tie(expression_rule, vars, std::ignore) =
-        jsonlogic::create_logic(jl_rule);
-
-    // jsonlogic::expr*                 rawexpr = expression_rule_.release();
-    // std::shared_ptr<jsonlogic::expr> expression_rule{rawexpr};
+    // this is not used ... PP (12/12/25)
+    // was: std::tie(expression_rule, vars, std::ignore) = jsonlogic::create_logic(jl_rule);
+    // new: jsonlogic::logic_rule jlrule = jsonlogic::create_logic(jl_rule);
 
     std::set<std::string> varset{};
     for (auto v : vars) {


### PR DESCRIPTION
Switch CLIPPy dependency to jl_nojson branch
Adapt apply_jl and remove_if_cmd to use jsonlogic::logic_rule::apply and truthy Replace data_accessor / unpack_value pattern with json_accessor and direct boolean evaluation Compile graph where clause using logic_rule, managed string views, and shared ownership