### PR TITLE
closes #86

### DIFF
--- a/src/libmetalldata/metall_graph.cpp
+++ b/src/libmetalldata/metall_graph.cpp
@@ -613,6 +613,22 @@ metall_graph::return_code metall_graph::nhops(
     },
     where);
 
+  std::vector<std::string> missing_vertices;
+  for (const auto& source : sources) {
+    if (!adj_list.contains(source)) {
+      missing_vertices.push_back(source);
+    }
+  }
+  if (!missing_vertices.empty()) {
+    std::string error = "source vertex/vertices invalid or missing: ";
+    for (size_t i = 0; i < missing_vertices.size(); ++i) {
+      if (i > 0) error += ", ";
+      error += missing_vertices[i];
+    }
+    to_return.error = error;
+    return to_return;
+  }
+
   std::map<std::string, size_t>    local_nhop_map;
   ygm::container::set<std::string> visited(m_comm, sources), cur_level(m_comm),
     next_level(m_comm, sources);


### PR DESCRIPTION
Closes #86. This actually didn't crash if there was an invalid source; it went all the way through set_node_column which caught the error. Now we avoid doing any of the BFS if a source is missing or invalid.