### PR TITLE
updates priv_random_idx

### DIFF
--- a/include/metalldata/detail/random_sample.hpp
+++ b/include/metalldata/detail/random_sample.hpp
@@ -37,44 +37,31 @@ namespace metalldata {
  *       `ygm::prefix_sum`, `ygm::bcast`).
  */
 template <typename T>
-std::unordered_set<T> random_sample(ygm::comm&            comm,
-                                    const std::vector<T>& filtered_ids,
-                                    const size_t k, uint64_t seed) {
+std::unordered_set<T> random_sample(const std::vector<T>& filtered_ids,
+                                    const size_t k, uint64_t seed,
+                                    ygm::comm& comm) {
   size_t local_count = filtered_ids.size();
   size_t global_count = ygm::sum(local_count, comm);
   size_t sample_size = std::min(global_count, k);
   size_t lower_bound = ygm::prefix_sum(local_count, comm);
 
-  comm.barrier();
+  std::unordered_set<size_t>            selected_indices;
+  std::mt19937                          gen(seed);
+  std::uniform_int_distribution<size_t> dist(0, global_count - 1);
 
-  std::vector<size_t> selected_indices;
-  selected_indices.reserve(sample_size);
-
-  if (comm.rank0()) {
-    std::unordered_set<size_t>            selection;
-    std::mt19937                          gen(seed);
-    std::uniform_int_distribution<size_t> dist(0, global_count - 1);
-
-    while (selection.size() < sample_size) {
-      selection.insert(dist(gen));
-    }
-
-    selected_indices.assign(selection.begin(), selection.end());
+  while (selected_indices.size() < sample_size) {
+    selected_indices.insert(dist(gen));
   }
-
-  ygm::bcast(selected_indices, 0, comm);
-
-  std::unordered_set<T> local_data;
+  std::unordered_set<T> to_return;
 
   for (const auto idx : selected_indices) {
     if ((idx >= lower_bound) && (idx < lower_bound + local_count)) {
       // local idx is guaranteed to be >= 0
       T id = filtered_ids.at(idx - lower_bound);
-      YGM_ASSERT_RELEASE(!local_data.contains(id));
-      local_data.insert(id);
+      to_return.insert(id);
     }
   }
 
-  return local_data;
+  return to_return;
 }
 }  // namespace metalldata

--- a/include/metalldata/detail/random_sample.hpp
+++ b/include/metalldata/detail/random_sample.hpp
@@ -1,0 +1,80 @@
+#pragma once
+#include <random>
+#include <unordered_set>
+#include <vector>
+#include <utility>
+
+#include <metalldata/metall_graph.hpp>
+#include <ygm/comm.hpp>
+
+namespace metalldata {
+
+/**
+ * @brief Draws a distributed random sample of up to `k` unique elements from a
+ *        globally distributed collection.
+ *
+ * Rank 0 selects `min(global_count, k)` unique global indices using a seeded
+ * Mersenne Twister, broadcasts the selection to all ranks, and each rank
+ * returns the subset of elements whose global indices fall within its local
+ * partition. The returned set on each rank contains only that rank's portion
+ * of the sample.
+ *
+ * @tparam T Element type. Must be hashable (usable as `std::unordered_set`
+ *           key) and copyable.
+ *
+ * @param comm          YGM communicator spanning all participating ranks.
+ * @param filtered_ids.   Local partition of candidate elements on this rank.
+ * @param k               Maximum number of elements to sample globally.
+ * @param seed            RNG seed for reproducible sampling (used only on
+ *                        rank 0).
+ *
+ * @return An `std::unordered_set<T>` containing this rank's share of the
+ *         sampled elements. The set is empty on ranks that own none of the
+ *         selected global indices.
+ *
+ * @note All ranks must call this function collectively; it contains an
+ *       internal barrier and collective operations (`ygm::sum`,
+ *       `ygm::prefix_sum`, `ygm::bcast`).
+ */
+template <typename T>
+std::unordered_set<T> random_sample(ygm::comm&            comm,
+                                    const std::vector<T>& filtered_ids,
+                                    const size_t k, uint64_t seed) {
+  size_t local_count = filtered_ids.size();
+  size_t global_count = ygm::sum(local_count, comm);
+  size_t sample_size = std::min(global_count, k);
+  size_t lower_bound = ygm::prefix_sum(local_count, comm);
+
+  comm.barrier();
+
+  std::vector<size_t> selected_indices;
+  selected_indices.reserve(sample_size);
+
+  if (comm.rank0()) {
+    std::unordered_set<size_t>            selection;
+    std::mt19937                          gen(seed);
+    std::uniform_int_distribution<size_t> dist(0, global_count - 1);
+
+    while (selection.size() < sample_size) {
+      selection.insert(dist(gen));
+    }
+
+    selected_indices.assign(selection.begin(), selection.end());
+  }
+
+  ygm::bcast(selected_indices, 0, comm);
+
+  std::unordered_set<T> local_data;
+
+  for (const auto idx : selected_indices) {
+    if ((idx >= lower_bound) && (idx < lower_bound + local_count)) {
+      // local idx is guaranteed to be >= 0
+      T id = filtered_ids.at(idx - lower_bound);
+      YGM_ASSERT_RELEASE(!local_data.contains(id));
+      local_data.insert(id);
+    }
+  }
+
+  return local_data;
+}
+}  // namespace metalldata

--- a/include/metalldata/detail/random_sample.hpp
+++ b/include/metalldata/detail/random_sample.hpp
@@ -14,23 +14,23 @@ namespace metalldata {
  *        globally distributed collection.
  *
  * Rank 0 selects `min(global_count, k)` unique global indices using a seeded
- * Mersenne Twister, broadcasts the selection to all ranks, and each rank
- * returns the subset of elements whose global indices fall within its local
- * partition. The returned set on each rank contains only that rank's portion
- * of the sample.
+ * Mersenne Twister and broadcasts them to all ranks. Each rank then maps the
+ * selected indices that fall within its local partition back to element values
+ * using `filtered_ids` and returns those elements.
  *
- * @tparam T Element type. Must be hashable (usable as `std::unordered_set`
+ * @tparam T Element type. Must be hashable (usable as an `std::unordered_set`
  *           key) and copyable.
  *
- * @param comm          YGM communicator spanning all participating ranks.
- * @param filtered_ids.   Local partition of candidate elements on this rank.
- * @param k               Maximum number of elements to sample globally.
- * @param seed            RNG seed for reproducible sampling (used only on
- *                        rank 0).
+ * @param comm         YGM communicator spanning all participating ranks.
+ * @param filtered_ids Local partition of candidate elements on this rank.
+ *                     Elements are treated as a contiguous segment of a
+ *                     virtual global array ordered by rank.
+ * @param k            Maximum number of elements to sample globally.
+ * @param seed         RNG seed for reproducible sampling (used only on rank 0).
  *
  * @return An `std::unordered_set<T>` containing this rank's share of the
- *         sampled elements. The set is empty on ranks that own none of the
- *         selected global indices.
+ *         sampled elements. Empty on ranks that own none of the selected
+ *         global indices.
  *
  * @note All ranks must call this function collectively; it contains an
  *       internal barrier and collective operations (`ygm::sum`,

--- a/include/metalldata/impl/metall_graph_set_column.ipp
+++ b/include/metalldata/impl/metall_graph_set_column.ipp
@@ -10,21 +10,33 @@ template <typename T>
 // 1. Creates the series
 // 2. For each record id, sets the series value at that record id to the value.
 //
-// TODO: this needs to be using something other than record_id_type here. We
-// might need to split this up into node and edge versions.
 
-result<> metall_graph::priv_set_column_by_idx(
+result<> metall_graph::priv_set_edge_column_by_idx(
   const metall_graph::series_name& col_name, const T& collection) {
-  using record_id_type = metall_graph::record_store_type::record_id_type;
   using val_type = typename T::mapped_type;
 
   result<> to_return;
-  auto     store = col_name.is_edge_series() ? m_pedges : m_pnodes;
   // create series
-  auto col_idx = store->add_series<val_type>(col_name.unqualified());
+  auto ser_idx = priv_add_edge_series<val_type>(col_name.unqualified());
 
-  for (const auto& [rid, value] : collection) {
-    store->set(col_idx, rid, value);
+  for (const auto& [eid, value] : collection) {
+    pl_set_edge_field(ser_idx, eid, value);
+  }
+
+  return to_return;
+}
+
+template <typename T>
+result<> metall_graph::priv_set_node_column_by_idx(
+  const metall_graph::series_name& col_name, const T& collection) {
+  using val_type = typename T::mapped_type;
+
+  result<> to_return;
+  // create series
+  auto ser_idx = priv_add_node_series<val_type>(col_name.unqualified());
+
+  for (const auto& [nid, value] : collection) {
+    pl_set_node_field(ser_idx, nid, value);
   }
 
   return to_return;
@@ -46,14 +58,14 @@ metalldata::result<> metall_graph::set_node_column(
   const series_name& nodecol_name, const T& collection) {
   result<> to_return;
 
-  using record_id_type = record_store_type::record_id_type;
+  // using record_id_type = record_store_type::record_id_type;
   using val_type = typename T::mapped_type;
 
   // create series
-  size_t nodecol_idx;
+  node_series_idx_type nodecol_idx;
   size_t invalid_nodes = 0;
   if constexpr (std::unsigned_integral<val_type>) {
-    nodecol_idx = m_pnodes->add_series<int64_t>(nodecol_name.unqualified());
+    nodecol_idx = priv_add_node_series<int64_t>(nodecol_name.unqualified());
 
     for (const auto& [node_name, value] : collection) {
       auto nid_o = pl_get_node_id(node_name);
@@ -64,19 +76,19 @@ metalldata::result<> metall_graph::set_node_column(
       if (value > std::numeric_limits<int64_t>::max()) {
         return std::unexpected("Cannot process unsigned integer value > 2**63");
       }
-      m_pnodes->set(nodecol_idx, std::to_underlying(nid_o.value()),
-                    static_cast<int64_t>(value));
+      pl_set_node_field(nodecol_idx, nid_o.value(),
+                        static_cast<int64_t>(value));
     }
 
   } else {
-    nodecol_idx = m_pnodes->add_series<val_type>(nodecol_name.unqualified());
+    nodecol_idx = priv_add_node_series<val_type>(nodecol_name.unqualified());
     for (const auto& [node_name, value] : collection) {
       auto nid_o = pl_get_node_id(node_name);
       if (!nid_o.has_value()) {
         ++invalid_nodes;
         continue;
       }
-      m_pnodes->set(nodecol_idx, std::to_underlying(nid_o.value()), value);
+      pl_set_node_field(nodecol_idx, nid_o.value(), value);
     }
   }
   if (invalid_nodes > 0) {

--- a/include/metalldata/impl/metall_graph_set_column.ipp
+++ b/include/metalldata/impl/metall_graph_set_column.ipp
@@ -12,7 +12,9 @@ template <typename T>
 //
 
 result<> metall_graph::priv_set_edge_column_by_idx(
-  const metall_graph::series_name& col_name, const T& collection) {
+  const metall_graph::series_name& col_name, const T& collection)
+  requires std::is_same_v<typename T::key_type, local_edge_idx_type>
+{
   using val_type = typename T::mapped_type;
 
   result<> to_return;
@@ -28,7 +30,9 @@ result<> metall_graph::priv_set_edge_column_by_idx(
 
 template <typename T>
 result<> metall_graph::priv_set_node_column_by_idx(
-  const metall_graph::series_name& col_name, const T& collection) {
+  const metall_graph::series_name& col_name, const T& collection)
+  requires std::is_same_v<typename T::key_type, local_node_idx_type>
+{
   using val_type = typename T::mapped_type;
 
   result<> to_return;
@@ -58,39 +62,21 @@ metalldata::result<> metall_graph::set_node_column(
   const series_name& nodecol_name, const T& collection) {
   result<> to_return;
 
-  // using record_id_type = record_store_type::record_id_type;
   using val_type = typename T::mapped_type;
 
   // create series
   node_series_idx_type nodecol_idx;
-  size_t invalid_nodes = 0;
-  if constexpr (std::unsigned_integral<val_type>) {
-    nodecol_idx = priv_add_node_series<int64_t>(nodecol_name.unqualified());
-
-    for (const auto& [node_name, value] : collection) {
-      auto nid_o = pl_get_node_id(node_name);
-      if (!nid_o.has_value()) {
-        ++invalid_nodes;
-        continue;
-      }
-      if (value > std::numeric_limits<int64_t>::max()) {
-        return std::unexpected("Cannot process unsigned integer value > 2**63");
-      }
-      pl_set_node_field(nodecol_idx, nid_o.value(),
-                        static_cast<int64_t>(value));
+  size_t               invalid_nodes = 0;
+  nodecol_idx = priv_add_node_series<val_type>(nodecol_name.unqualified());
+  for (const auto& [node_name, value] : collection) {
+    auto nid_o = pl_get_node_id(node_name);
+    if (!nid_o.has_value()) {
+      ++invalid_nodes;
+      continue;
     }
-
-  } else {
-    nodecol_idx = priv_add_node_series<val_type>(nodecol_name.unqualified());
-    for (const auto& [node_name, value] : collection) {
-      auto nid_o = pl_get_node_id(node_name);
-      if (!nid_o.has_value()) {
-        ++invalid_nodes;
-        continue;
-      }
-      pl_set_node_field(nodecol_idx, nid_o.value(), value);
-    }
+    pl_set_node_field(nodecol_idx, nid_o.value(), value);
   }
+
   if (invalid_nodes > 0) {
     to_return.add_warnings(invalid_nodes, "invalid nodes");
   }

--- a/include/metalldata/metall_graph.hpp
+++ b/include/metalldata/metall_graph.hpp
@@ -473,7 +473,7 @@ class metall_graph {
                            const T&           collection);
 
   /**
-   * @brief Updates reverse node index after fresh edge ingestion.   Collective
+   * @brief Updates reverse node index after fresh edge ingestion. Collective
    * method.
    *
    */
@@ -524,11 +524,13 @@ class metall_graph {
 
   template <typename T>
   result<> priv_set_edge_column_by_idx(const series_name& col_name,
-                                       const T&           collection);
+                                       const T&           collection)
+    requires std::is_same_v<typename T::key_type, local_edge_idx_type>;
 
   template <typename T>
   result<> priv_set_node_column_by_idx(const series_name& col_name,
-                                       const T&           collection);
+                                       const T&           collection)
+    requires std::is_same_v<typename T::key_type, local_node_idx_type>;
 
   static count_types priv_series_to_count_type(
     const record_store_type::series_type& sv);

--- a/include/metalldata/metall_graph.hpp
+++ b/include/metalldata/metall_graph.hpp
@@ -517,18 +517,18 @@ class metall_graph {
    */
   result<> priv_check_index_integrity() const;
 
-  std::unordered_set<record_id_type> priv_random_idx(
-    const std::unordered_set<record_id_type>& filtered_ids_set, size_t k,
-    uint64_t seed);
-
   // Using YGM's default partitioner to assign node owner
   ygm::container::detail::hash_partitioner<
     ygm::container::detail::hash<std::string_view>>
     m_partitioner;
 
   template <typename T>
-  result<> priv_set_column_by_idx(const series_name& col_name,
-                                  const T&           collection);
+  result<> priv_set_edge_column_by_idx(const series_name& col_name,
+                                       const T&           collection);
+
+  template <typename T>
+  result<> priv_set_node_column_by_idx(const series_name& col_name,
+                                       const T&           collection);
 
   static count_types priv_series_to_count_type(
     const record_store_type::series_type& sv);

--- a/src/libmetalldata/metall_graph_degree.cpp
+++ b/src/libmetalldata/metall_graph_degree.cpp
@@ -273,13 +273,13 @@ result<> metall_graph::degrees2(series_name in_name, series_name out_name,
   // explicit here.
   m_comm.barrier();
 
-  std::map<std::string, int64_t> indeg_i64 = {indegrees.begin(),
-                                              indegrees.end()};
-  std::map<std::string, int64_t> outdeg_i64 = {indegrees.begin(),
-                                               indegrees.end()};
-  auto to_return = set_node_column(in_name, indeg_i64);
+  std::map<std::string, int64_t> local_indeg_i64 = {indegrees.begin(),
+                                                    indegrees.end()};
+  std::map<std::string, int64_t> local_outdeg_i64 = {indegrees.begin(),
+                                                     indegrees.end()};
+  auto to_return = set_node_column(in_name, local_indeg_i64);
 
-  auto to_return2 = set_node_column(out_name, outdeg_i64);
+  auto to_return2 = set_node_column(out_name, local_outdeg_i64);
 
   to_return.merge_warnings(to_return2);
 

--- a/src/libmetalldata/metall_graph_degree.cpp
+++ b/src/libmetalldata/metall_graph_degree.cpp
@@ -273,8 +273,14 @@ result<> metall_graph::degrees2(series_name in_name, series_name out_name,
   // explicit here.
   m_comm.barrier();
 
-  auto to_return = set_node_column(in_name, indegrees);
-  auto to_return2 = set_node_column(out_name, outdegrees);
+  std::map<std::string, int64_t> indeg_i64 = {indegrees.begin(),
+                                              indegrees.end()};
+  std::map<std::string, int64_t> outdeg_i64 = {indegrees.begin(),
+                                               indegrees.end()};
+  auto to_return = set_node_column(in_name, indeg_i64);
+
+  auto to_return2 = set_node_column(out_name, outdeg_i64);
+
   to_return.merge_warnings(to_return2);
 
   return to_return;

--- a/src/libmetalldata/metall_graph_sample.cpp
+++ b/src/libmetalldata/metall_graph_sample.cpp
@@ -1,5 +1,6 @@
 #include <metalldata/metall_graph.hpp>
 #include <utility>
+#include "ygm/utility/assert.hpp"
 #define BOOST_JSON_SRC_HPP  // This is a temp hack until YGM removes the src.hpp
                             // inclusion
 #include <ygm/utility/boost_json.hpp>
@@ -17,13 +18,7 @@ result<> metall_graph::sample_edges(
       std::format("series {} already exists", series_name.qualified()));
   }
 
-  uint64_t seed;
-  if (optseed.has_value()) {
-    seed = optseed.value();
-  } else {
-    std::random_device rd;
-    seed = rd();
-  }
+  uint64_t seed = optseed.value_or(0);
 
   std::vector<local_edge_idx_type> filtered_ids;
   priv_for_all_edges(
@@ -43,13 +38,7 @@ result<> metall_graph::sample_edges(
 bjsn::array metall_graph::select_sample_edges(
   size_t k, const std::vector<metall_graph::series_name>& metadata,
   std::optional<uint64_t> optseed, const metall_graph::where_clause& where) {
-  uint64_t seed;
-  if (optseed.has_value()) {
-    seed = optseed.value();
-  } else {
-    std::random_device rd;
-    seed = rd();
-  }
+  uint64_t seed = optseed.value_or(0);
 
   std::vector<local_edge_idx_type> filtered_ids;
   priv_for_all_edges(
@@ -141,13 +130,7 @@ result<> metall_graph::sample_nodes(
       std::format("Series {} already exists", series_name.qualified()));
   }
 
-  uint64_t seed;
-  if (optseed.has_value()) {
-    seed = optseed.value();
-  } else {
-    std::random_device rd;
-    seed = rd();
-  }
+  uint64_t seed = optseed.value_or(0);
 
   std::vector<local_node_idx_type> filtered_ids;
   priv_for_all_nodes(
@@ -167,13 +150,7 @@ result<> metall_graph::sample_nodes(
 bjsn::array metall_graph::select_sample_nodes(
   size_t k, const std::vector<metall_graph::series_name>& metadata,
   std::optional<uint64_t> optseed, const metall_graph::where_clause& where) {
-  uint64_t seed;
-  if (optseed.has_value()) {
-    seed = optseed.value();
-  } else {
-    std::random_device rd;
-    seed = rd();
-  }
+  uint64_t seed = optseed.value_or(0);
 
   std::vector<local_node_idx_type> filtered_ids;
   priv_for_all_nodes(

--- a/src/libmetalldata/metall_graph_sample.cpp
+++ b/src/libmetalldata/metall_graph_sample.cpp
@@ -61,23 +61,22 @@ bjsn::array metall_graph::select_sample_edges(
     unqual_metadata.push_back(std::string(sn.unqualified()));
   }
 
-  std::unordered_map<series_index_type, series_name> idx_to_name;
+  std::unordered_map<edge_series_idx_type, series_name> idx_to_name;
   for (const auto& sname : metadata) {
-    auto idx_o = m_pedges->find_series(sname.unqualified());
-    if (!idx_o.has_value()) {
+    auto eidx_o = pl_find_edge_series(sname.unqualified());
+    if (!eidx_o.has_value()) {
       return {};
     }
-    auto idx = idx_o.value();
-    idx_to_name[idx] = sname;
+    auto eidx = eidx_o.value();
+    idx_to_name[eidx] = sname;
   }
 
   bjsn::array rows;
 
   for (const auto& eid : local_data) {
     bjsn::object row;
-    for (const auto& [idx, sname] : idx_to_name) {
-      auto val_o = m_pedges->get_dynamic(idx, std::to_underlying(eid));
-
+    for (const auto& [eidx, sname] : idx_to_name) {
+      auto val_o = pl_get_edge_field(eidx, eid);
       if (!val_o.has_value()) {
         continue;
       }
@@ -187,23 +186,22 @@ bjsn::array metall_graph::select_sample_nodes(
     unqual_metadata.push_back(std::string(sn.unqualified()));
   }
 
-  std::unordered_map<series_index_type, series_name> idx_to_name;
+  std::unordered_map<node_series_idx_type, series_name> idx_to_name;
   for (const auto& sname : metadata) {
-    auto idx_o = m_pnodes->find_series(sname.unqualified());
-    if (!idx_o.has_value()) {
+    auto nidx_o = pl_find_node_series(sname.unqualified());
+    if (!nidx_o.has_value()) {
       return {};
     }
-    auto idx = idx_o.value();
-    idx_to_name[idx] = sname;
+    auto nidx = nidx_o.value();
+    idx_to_name[nidx] = sname;
   }
 
   bjsn::array rows;
 
   for (const auto& nid : local_data) {
     bjsn::object row;
-    for (const auto& [idx, sname] : idx_to_name) {
-      auto val_o = m_pnodes->get_dynamic(idx, std::to_underlying(nid));
-
+    for (const auto& [nidx, sname] : idx_to_name) {
+      auto val_o = pl_get_node_field(nidx, nid);
       if (!val_o.has_value()) {
         continue;
       }

--- a/src/libmetalldata/metall_graph_sample.cpp
+++ b/src/libmetalldata/metall_graph_sample.cpp
@@ -3,59 +3,9 @@
 #define BOOST_JSON_SRC_HPP  // This is a temp hack until YGM removes the src.hpp
                             // inclusion
 #include <ygm/utility/boost_json.hpp>
+#include <metalldata/detail/random_sample.hpp>
 
 namespace metalldata {
-// Returns randomly-selected record ids (edges when sample_edges is true, nodes
-// otherwise) that exist on this rank. Selection is uniform across all ranks.
-std::unordered_set<metall_graph::record_id_type> metall_graph::priv_random_idx(
-  const std::unordered_set<record_id_type>& filtered_ids_set, const size_t k,
-  uint64_t seed) {
-  std::vector<record_id_type> filtered_ids(filtered_ids_set.begin(),
-                                           filtered_ids_set.end());
-
-  size_t local_count  = filtered_ids.size();
-  size_t global_count = ygm::sum(local_count, m_comm);
-  size_t sample_size  = std::min(global_count, k);
-  size_t lower_bound  = ygm::prefix_sum(local_count, m_comm);
-
-  m_comm.barrier();
-
-  std::vector<size_t> selected_indices;
-  selected_indices.reserve(sample_size);
-
-  if (m_comm.rank0()) {
-    std::unordered_set<size_t>            selection;
-    std::mt19937                          gen(seed);
-    std::uniform_int_distribution<size_t> dist(0, global_count - 1);
-
-    while (selection.size() < sample_size) {
-      selection.insert(dist(gen));
-    }
-
-    selected_indices.assign(selection.begin(), selection.end());
-  }
-
-  ygm::bcast(selected_indices, 0, m_comm);
-
-  std::unordered_set<record_id_type> local_data;
-
-  for (const auto idx : selected_indices) {
-    if ((idx >= lower_bound) && (idx < lower_bound + local_count)) {
-      // local idx is guaranteed to be >= 0
-      record_id_type rid = filtered_ids.at(idx - lower_bound);
-      YGM_ASSERT_RELEASE(!local_data.contains(rid));
-      local_data.insert(rid);
-    }
-  }
-
-  return local_data;
-}
-
-// std::unordered_set<metall_graph::record_id_type>
-// metall_graph::priv_random_edge_idx(const size_t k, uint64_t seed,
-//                                    const where_clause& where) {
-//   return priv_random_idx(true, k, seed, where);
-// }
 
 // Creates a column of bool where true values indicate that the edge has been
 // selected during the random sample.
@@ -75,18 +25,18 @@ result<> metall_graph::sample_edges(
     seed = rd();
   }
 
-  std::unordered_set<record_id_type> filtered_ids_set;
-  priv_for_all_edges([&](local_edge_idx_type eid) { filtered_ids_set.insert(std::to_underlying(eid)); },
-                     where);
+  std::vector<local_edge_idx_type> filtered_ids;
+  priv_for_all_edges(
+    [&](local_edge_idx_type eid) { filtered_ids.emplace_back(eid); }, where);
 
-  auto local_data = priv_random_idx(filtered_ids_set, k, seed);
-  std::unordered_map<metall_graph::record_id_type, bool> local_map{};
+  auto local_data = random_sample(m_comm, filtered_ids, k, seed);
+  std::unordered_map<local_edge_idx_type, bool> local_map{};
 
-  for (const auto rid : local_data) {
-    local_map[rid] = true;
+  for (const auto id : local_data) {
+    local_map[id] = true;
   }
   m_comm.barrier();
-  priv_set_column_by_idx(series_name, local_map);
+  priv_set_edge_column_by_idx(series_name, local_map);
   return result<>{};
 }
 
@@ -101,10 +51,10 @@ bjsn::array metall_graph::select_sample_edges(
     seed = rd();
   }
 
-  std::unordered_set<record_id_type> filtered_ids_set;
-  priv_for_all_edges([&](local_edge_idx_type eid) { filtered_ids_set.insert(std::to_underlying(eid)); },
-                     where);
-  auto local_data = priv_random_idx(filtered_ids_set, k, seed);
+  std::vector<local_edge_idx_type> filtered_ids;
+  priv_for_all_edges(
+    [&](local_edge_idx_type eid) { filtered_ids.emplace_back(eid); }, where);
+  auto local_data = random_sample(m_comm, filtered_ids, k, seed);
 
   std::vector<std::string> unqual_metadata;
   for (const auto& sn : metadata) {
@@ -123,10 +73,10 @@ bjsn::array metall_graph::select_sample_edges(
 
   bjsn::array rows;
 
-  for (const auto& rid : local_data) {
+  for (const auto& eid : local_data) {
     bjsn::object row;
     for (const auto& [idx, sname] : idx_to_name) {
-      auto val_o = m_pedges->get_dynamic(idx, rid);
+      auto val_o = m_pedges->get_dynamic(idx, std::to_underlying(eid));
 
       if (!val_o.has_value()) {
         continue;
@@ -176,7 +126,7 @@ bjsn::array metall_graph::select_sample_edges(
 // // Returns a set of randomly-selected edge indices on this rank.
 // // The indices are uniformly chosen from all the edges in the graph.
 // // Only indices that exist on this rank are returned in the set
-// std::unordered_set<metall_graph::record_id_type>
+// std::unordered_set<local_node_idx_type>
 // metall_graph::priv_random_node_idx(const size_t k, uint64_t seed,
 //                                    const where_clause& where) {
 //   return priv_random_idx(false, k, seed, where);
@@ -200,18 +150,18 @@ result<> metall_graph::sample_nodes(
     seed = rd();
   }
 
-  std::unordered_set<record_id_type> filtered_ids_set;
-  priv_for_all_nodes([&](local_node_idx_type nid) { filtered_ids_set.insert(std::to_underlying(nid)); },
-                     where);
+  std::vector<local_node_idx_type> filtered_ids;
+  priv_for_all_nodes(
+    [&](local_node_idx_type nid) { filtered_ids.emplace_back(nid); }, where);
 
-  auto local_data = priv_random_idx(filtered_ids_set, k, seed);
-  std::unordered_map<metall_graph::record_id_type, bool> local_map{};
+  auto local_data = random_sample(m_comm, filtered_ids, k, seed);
+  std::unordered_map<local_node_idx_type, bool> local_map{};
 
   for (const auto rid : local_data) {
     local_map[rid] = true;
   }
   m_comm.barrier();
-  priv_set_column_by_idx(series_name, local_map);
+  priv_set_node_column_by_idx(series_name, local_map);
   return result<>{};
 }
 
@@ -226,11 +176,11 @@ bjsn::array metall_graph::select_sample_nodes(
     seed = rd();
   }
 
-  std::unordered_set<record_id_type> filtered_ids_set;
-  priv_for_all_nodes([&](local_node_idx_type nid) { filtered_ids_set.insert(std::to_underlying(nid)); },
-                     where);
+  std::vector<local_node_idx_type> filtered_ids;
+  priv_for_all_nodes(
+    [&](local_node_idx_type nid) { filtered_ids.emplace_back(nid); }, where);
 
-  auto local_data = priv_random_idx(filtered_ids_set, k, seed);
+  auto local_data = random_sample(m_comm, filtered_ids, k, seed);
 
   std::vector<std::string> unqual_metadata;
   for (const auto& sn : metadata) {
@@ -249,10 +199,10 @@ bjsn::array metall_graph::select_sample_nodes(
 
   bjsn::array rows;
 
-  for (const auto& rid : local_data) {
+  for (const auto& nid : local_data) {
     bjsn::object row;
     for (const auto& [idx, sname] : idx_to_name) {
-      auto val_o = m_pnodes->get_dynamic(idx, rid);
+      auto val_o = m_pnodes->get_dynamic(idx, std::to_underlying(nid));
 
       if (!val_o.has_value()) {
         continue;

--- a/src/libmetalldata/metall_graph_sample.cpp
+++ b/src/libmetalldata/metall_graph_sample.cpp
@@ -29,7 +29,7 @@ result<> metall_graph::sample_edges(
   priv_for_all_edges(
     [&](local_edge_idx_type eid) { filtered_ids.emplace_back(eid); }, where);
 
-  auto local_data = random_sample(m_comm, filtered_ids, k, seed);
+  auto local_data = random_sample(filtered_ids, k, seed, m_comm);
   std::unordered_map<local_edge_idx_type, bool> local_map{};
 
   for (const auto id : local_data) {
@@ -54,7 +54,7 @@ bjsn::array metall_graph::select_sample_edges(
   std::vector<local_edge_idx_type> filtered_ids;
   priv_for_all_edges(
     [&](local_edge_idx_type eid) { filtered_ids.emplace_back(eid); }, where);
-  auto local_data = random_sample(m_comm, filtered_ids, k, seed);
+  auto local_data = random_sample(filtered_ids, k, seed, m_comm);
 
   std::vector<std::string> unqual_metadata;
   for (const auto& sn : metadata) {
@@ -154,7 +154,7 @@ result<> metall_graph::sample_nodes(
   priv_for_all_nodes(
     [&](local_node_idx_type nid) { filtered_ids.emplace_back(nid); }, where);
 
-  auto local_data = random_sample(m_comm, filtered_ids, k, seed);
+  auto local_data = random_sample(filtered_ids, k, seed, m_comm);
   std::unordered_map<local_node_idx_type, bool> local_map{};
 
   for (const auto rid : local_data) {
@@ -180,7 +180,7 @@ bjsn::array metall_graph::select_sample_nodes(
   priv_for_all_nodes(
     [&](local_node_idx_type nid) { filtered_ids.emplace_back(nid); }, where);
 
-  auto local_data = random_sample(m_comm, filtered_ids, k, seed);
+  auto local_data = random_sample(filtered_ids, k, seed, m_comm);
 
   std::vector<std::string> unqual_metadata;
   for (const auto& sn : metadata) {


### PR DESCRIPTION
refactors priv_random_idx into a free function random_sample, breaks out priv_set_column to node and edge, and uses metallgraph methods instead of multiseries records

Closes #134 